### PR TITLE
Refactor toast message into util function and use toast with spinner

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -218,4 +218,13 @@ export default {
     /* .component-fade-leave-active below version 2.1.8 */ {
     opacity: 0;
   }
+
+  .toast-wrapper {
+    display: flex;
+    align-items: center;
+  }
+
+  .toast-message {
+    margin-left: 10px;
+  }
 </style>

--- a/src/main.js
+++ b/src/main.js
@@ -3,14 +3,16 @@
 import Vue from 'vue'
 import App from './App'
 import router from './router'
-import { BootstrapVue, BIconLockFill } from 'bootstrap-vue'
+import { BootstrapVue, BIconLockFill, BootstrapVueIcons } from 'bootstrap-vue'
 import { store } from './store/'
 
 Vue.use(BootstrapVue)
+Vue.use(BootstrapVueIcons)
 Vue.component('BIconLockFill', BIconLockFill)
 
 import 'bootstrap/dist/css/bootstrap.min.css'
 import 'bootstrap-vue/dist/bootstrap-vue.css'
+import 'bootstrap-vue/dist/bootstrap-vue-icons.min.css'
 
 Vue.config.productionTip = false
 

--- a/src/util/showToast.js
+++ b/src/util/showToast.js
@@ -1,0 +1,61 @@
+export const showPendingToast = (context) => {
+    const h = context.$createElement;
+    const vNodesMsg = h(
+        'div', {class: 'toast-wrapper'},
+        [
+            h('b-spinner', {props: { type: 'grow', small: true, variant: 'info' } }),
+            h('div', {class: 'toast-message'}, ['Pending Confirmation...'])
+        ]
+    )
+
+    context.$bvToast.toast(
+        [vNodesMsg], {
+            variant: 'info',
+            solid: true,
+            noCloseButton: true,
+            appendToast: true
+        }
+    )
+}
+
+export const showSuccessToast = (context, message = null) => {
+    const h = context.$createElement;
+
+    const vNodesMsg = h(
+        'div', {class: 'toast-wrapper'},
+        [
+           h('b-icon', { props: { icon: 'check', fontScale: 2}}),
+           h('div', {class: 'toast-message'}, [message || 'Transaction Complete!'])
+        ]
+    )
+
+    context.$bvToast.toast(
+        [vNodesMsg], {
+            variant: 'success',
+            solid: true,
+            noCloseButton: true,
+            appendToast: true
+        }
+    )
+}
+
+export const showRejectedToast = (context) => {
+    const h = context.$createElement;
+
+    const vNodesMsg = h(
+        'div', {class: 'toast-wrapper'},
+        [
+           h('b-icon', { props: { icon: 'exclamation-circle', fontScale: 2}}),
+           h('div', {class: 'toast-message'}, ['Transaction Rejected.'])
+        ]
+    )
+
+    context.$bvToast.toast(
+        [vNodesMsg], {
+            variant: 'warning',
+            solid: true,
+            noCloseButton: true,
+            appendToast: true
+        }
+    )
+}


### PR DESCRIPTION
Changes:
- Refactored triggering toast into a util function, which will trigger pending, success, rejected toasts correspondingly
- Modified `CryptContent` to use toasts instead of spinner and showing transaction status