### PR TITLE
disable watch to reduce network requests

### DIFF
--- a/src/components/CryptContent.vue
+++ b/src/components/CryptContent.vue
@@ -496,6 +496,8 @@ export default {
       .then(res => {
         if (res === undefined) {
           throw new Error('result is undefined in openBooster')
+        } else {
+          this.getAllCards()
         }
       })
       .catch(err => {

--- a/src/components/CryptContent.vue
+++ b/src/components/CryptContent.vue
@@ -262,18 +262,19 @@ export default {
       },
       deep: true
     },
-    'currentEvent': {
-      handler: function(newValue, oldValue) {
-        if (newValue) {
-          if(this.subscriptionState == 0){
-            this.getAllCards();
-          }
-          if(oldValue && newValue.transactionHash !== oldValue.transactionHash){
-            showSuccessToast(this, 'Confirmed! Balance updated')
-          }
-        }
-      }
-    }
+    // TODO: figure out a more intelligent way of reloading cards.
+    // 'currentEvent': {
+    //   handler: function(newValue, oldValue) {
+    //     if (newValue) {
+    //       if(this.subscriptionState == 0){
+    //         this.getAllCards();
+    //       }
+    //       if(oldValue && newValue.transactionHash !== oldValue.transactionHash){
+    //         showSuccessToast(this, 'Confirmed! Balance updated')
+    //       }
+    //     }
+    //   }
+    // }
   },
   methods : {
     openGiftModal: function(id) {


### PR DESCRIPTION
The watch doesn't do anything other than showing a toast message and reload all cards. 

We can disable this since updating balance is handled by `UniverseBalances` component. 

I will look into a more intelligent way of reloading cards