### PR TITLE
Infinite scroll on shop page with lots of refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ dist
 .yarn/install-state.gz
 .pnp.*
 node_modules
+
+
+.DS_Store

--- a/src/components/ShopContent.vue
+++ b/src/components/ShopContent.vue
@@ -36,125 +36,178 @@
         </b-col>
       </b-row>
     </b-modal>
-
-    <!--main role="main" class="container"-->
     <div class="jumbotron">
-      <p>
+      <div>
         <UniverseBalances></UniverseBalances>
-      </p>
+      </div>
       <h1><b-icon-tag-fill /> Minting Shop</h1>
       <p>
-        The Shop is a place to mint limited edition Cryptoz Cards NFT tokens. Some cards
-        are free, some have a cost. You may also buy and <router-link to="/my-cryptoz-nfts">open a booster card</router-link>,
+        The Shop is a place to mint limited edition Cryptoz Cards NFT tokens.
+        Some cards are free, some have a cost. You may also buy and
+        <router-link to="/my-cryptoz-nfts">open a booster card</router-link>,
         which will randomly mint an unlimited edition NFT token.
       </p>
       <p>
         To mint a FREE NFT Or buy a Limited edition NFT, you will need the
-        required minimum balance of CZXP tokens displayed on the botton of the card to unlock the minting button. The newly minted NFT will appear in <router-link to="/my-cryptoz-nfts"> Your NFT Crypt</router-link> once the transaction is confirmed. CZXP is NOT burned when minting
+        required minimum balance of CZXP tokens displayed on the botton of the
+        card to unlock the minting button. The newly minted NFT will appear in
+        <router-link to="/my-cryptoz-nfts"> Your NFT Crypt</router-link> once
+        the transaction is confirmed. CZXP is NOT burned when minting
       </p>
       <div class="row">
         <div class="col">
           <b-button
             v-b-tooltip.hover="'Earn +120 CZXP per credit'"
             class="btn btn-danger"
-            v-bind:disabled="balance < 2000000000000000"
+            v-bind:disabled="balance < 2000000000000000 || isBuyingBooster"
             v-b-modal.buy-boosters-modal
-            >Buy <b-icon-lightning-fill />  Booster Credits @ 0.002 BNB</b-button>
+            >Buy <b-icon-lightning-fill /> Booster Credits @ 0.002 BNB</b-button
+          >
         </div>
       </div>
 
-      <br />
-      <OwnerBalances></OwnerBalances>
-      <br />
+      <div class="owner-balances">
+        <OwnerBalances></OwnerBalances>
+      </div>
 
-      <div class="row">
+      <div class="loading" v-if="isLoadingShopCards">
+        <b-spinner style="width: 3rem; height: 3rem" type="grow"></b-spinner>
+      </div>
+      <div v-else>
+        <div class="row sort-wrapper">
           <div class="col text-left">
             <SortDropdown @sort-by-attr="sortByAttr"></SortDropdown>
           </div>
         </div>
-      <br>
-      <div class="flex-row">
-        <div v-for="card in sortedCards" :key="card.type_id" class="shop-card-item">
-          <OwnedCardContent
-            :type_id="card.type_id"
-            :name="card.name"
-            :cost="card.cost"
-            :cset="card.card_set"
-            :edition_current="card.edition_current"
-            :edition_total="card.edition_total"
-            :in_store="card.in_store"
-            :level="card.card_level"
-            :unlock_czxp="card.unlock_czxp"
-            :buy_czxp="card.buy_czxp"
-            :transfer_czxp="card.transfer_czxp"
-            :sacrifice_czxp="card.sacrifice_czxp"
-            :image="card.image"
-            :card_class="card.rarity"
-            :card_owned="false"
-          ></OwnedCardContent>
-          <div class="card-button-container">
-            <div
-              v-if="card.soldOut == 1"
-              id="sold-button-wrapper"
-              v-b-tooltip.hover="getSoldCardToolTipText"
-              class="disabled-btn"
-            >
-              <button id="owned-button" disabled class="btn btn-danger">
-              SOLD OUT!
-              </button>
-            </div>
-            <div
-              v-else-if="!card.isOwned"
-              id="buy-get-button-wrapper"
-              :class="balance <= card.cost || czxpBalance < parseInt(card.unlock_czxp) ? 'disabled-btn' : ''"
-            >
-              <div v-if="card.cost > 0" id="buyBtnwrapper" v-b-tooltip.hover="buyBtnTooltipText(card.cost, card.unlock_czxp)">
-                <b-button id="buy-button" :disabled="balance <= card.cost || czxpBalance < parseInt(card.unlock_czxp)" variant="primary" v-on:click="buyCard(card)">
-                  <b-icon-lock-fill v-if="balance <= card.cost || czxpBalance < parseInt(card.unlock_czxp)"></b-icon-lock-fill> Mint NFT for {{card.cost}} BNB
+
+        <div class="flex-row">
+          <div
+            v-for="card in displayCards"
+            :key="card.type_id"
+            class="shop-card-item"
+          >
+            <OwnedCardContent
+              :type_id="card.type_id"
+              :name="card.name"
+              :cost="card.cost"
+              :cset="card.card_set"
+              :edition_current="card.edition_current"
+              :edition_total="card.edition_total"
+              :in_store="card.in_store"
+              :level="card.card_level"
+              :unlock_czxp="card.unlock_czxp"
+              :buy_czxp="card.buy_czxp"
+              :transfer_czxp="card.transfer_czxp"
+              :sacrifice_czxp="card.sacrifice_czxp"
+              :image="card.image"
+              :card_class="card.rarity"
+              :card_owned="false"
+            ></OwnedCardContent>
+            <div class="card-button-container">
+              <div
+                v-if="card.soldOut == 1"
+                id="sold-button-wrapper"
+                v-b-tooltip.hover="getSoldCardToolTipText"
+                class="disabled-btn"
+              >
+                <b-button id="owned-button" disabled class="btn btn-danger">
+                  SOLD OUT!
                 </b-button>
               </div>
-              <div v-else id="getBtnwrapper" v-b-tooltip.hover="getBtnTooltipText(card.unlock_czxp)">
-                <button id="get-button"  class="btn btn-primary" :disabled="czxpBalance < parseInt(card.unlock_czxp)" v-on:click="getCardForFree(card.type_id)">
-                  <b-icon-lock-fill v-if="czxpBalance < parseInt(card.unlock_czxp)"></b-icon-lock-fill> Mint for FREE
+              <div
+                v-else-if="!card.isOwned"
+                id="buy-get-button-wrapper"
+                :class="
+                  balance <= card.cost ||
+                  czxpBalance < parseInt(card.unlock_czxp)
+                    ? 'disabled-btn'
+                    : ''
+                "
+              >
+                <div
+                  v-if="card.cost > 0"
+                  id="buyBtnwrapper"
+                  v-b-tooltip.hover="
+                    buyBtnTooltipText(card.cost, card.unlock_czxp)
+                  "
+                >
+                  <b-button
+                    id="buy-button"
+                    :disabled="
+                      balance <= card.cost ||
+                      czxpBalance < parseInt(card.unlock_czxp)
+                    "
+                    variant="primary"
+                    v-on:click="buyCard(card)"
+                  >
+                    <b-icon-lock-fill
+                      v-if="
+                        balance <= card.cost ||
+                        czxpBalance < parseInt(card.unlock_czxp)
+                      "
+                    ></b-icon-lock-fill>
+                    Mint NFT for {{ card.cost }} BNB
+                  </b-button>
+                </div>
+                <div
+                  v-else
+                  id="getBtnwrapper"
+                  v-b-tooltip.hover="getBtnTooltipText(card.unlock_czxp)"
+                >
+                  <button
+                    id="get-button"
+                    class="btn btn-primary"
+                    :disabled="czxpBalance < parseInt(card.unlock_czxp)"
+                    v-on:click="getCardForFree(card.type_id)"
+                  >
+                    <b-icon-lock-fill
+                      v-if="czxpBalance < parseInt(card.unlock_czxp)"
+                    ></b-icon-lock-fill>
+                    Mint for FREE
+                  </button>
+                </div>
+              </div>
+
+              <div
+                v-else-if="card.isOwned"
+                id="owned-button-wrapper"
+                v-b-tooltip.hover="getOwnedCardToolTipText"
+                class="disabled-btn"
+              >
+                <button id="owned-button" disabled class="btn btn-info">
+                  You already minted one
                 </button>
               </div>
             </div>
-            <div
-              v-else-if="card.isOwned"
-              id="owned-button-wrapper"
-              v-b-tooltip.hover="getOwnedCardToolTipText"
-              class="disabled-btn"
+          </div>
+          <div class="load-more" v-if="shouldRenderLoadMore">
+            <b-button variant="outline-success" @click="loadMoreCards"
+              >Load more</b-button
             >
-              <button id="owned-button" disabled class="btn btn-info">
-                You already minted one
-              </button>
-            </div>
           </div>
         </div>
       </div>
     </div>
-    <!--/main-->
   </div>
 </template>
 
 <script>
-import axios from 'axios'
-import OwnedCardContent from '@/components/OwnedCardContent.vue'
-import UniverseBalances from '@/components/UniverseBalances.vue'
-import OwnerBalances from '@/components/OwnerBalances.vue'
-import SortDropdown from '@/components/SortDropdown.vue'
-import { getRarity, dynamicSort} from '../helpers'
-import { showErrorToast, showPendingToast, showRejectedToast, showSuccessToast } from "../util/showToast";
-import getCardType from '../util/getCardType'
 import {
-  BRow,
-  BCol,
-  BButton,
-  BSpinner,
-} from 'bootstrap-vue'
+  showPendingToast,
+  showRejectedToast,
+  showSuccessToast,
+} from "../util/showToast";
+
+import OwnedCardContent from "@/components/OwnedCardContent.vue";
+import UniverseBalances from "@/components/UniverseBalances.vue";
+import OwnerBalances from "@/components/OwnerBalances.vue";
+import SortDropdown from "@/components/SortDropdown.vue";
+
+import { mapGetters } from "vuex";
+
+import { BRow, BCol, BButton, BSpinner } from "bootstrap-vue";
 
 export default {
-  name: "ShopContent",
   components: {
     OwnedCardContent,
     UniverseBalances,
@@ -165,15 +218,33 @@ export default {
     BButton,
     BSpinner,
   },
+  data() {
+    return {
+      buyBtnTooltipTextContent: "Click to buy a copy of this card",
+      buyBtnBlockedTooltipTextContent:
+        "You do not have enough BNB or CZXP tokens to purchase this card",
+      getBtnTooltipTextContent: "Click to mint a copy of this card at no cost",
+      getBtnBlockedTooltipTextContent:
+        "You do not have enough CZXP tokens to unlock minting an NFT of this type",
+      getOwnedCardToolTipText: "You can only mint 1 card of each type",
+      getSoldCardToolTipText:
+        "All NFTs of this type have been minted, check markets",
+      totalCreditsToBuy: 1,
+      isBuyingBooster: false,
+      isCardSorted: false,
+      pageSize: 10,
+      paginatedCards: [],
+      sortedPaginatedCards: [],
+      pageNext: 0,
+      sortedPageNext: 0,
+    };
+  },
   computed: {
-    web3() {
-      return this.$store.state.web3;
-    },
     CryptozInstance() {
       return this.$store.state.contractInstance.cryptoz;
     },
-    wallet() {
-      return parseFloat(web3.utils.fromWei(this.$store.state.web3.balance.toString()), "ether");
+    czxpBalance() {
+      return this.$store.state.czxpBalance;
     },
     balance() {
       return this.$store.state.web3.balance;
@@ -181,384 +252,328 @@ export default {
     coinbase() {
       return this.$store.state.web3.coinbase;
     },
-    totalCyptozTypes() {
-      return this.$store.state.totalCryptozTypes;
-    },
-    czxpBalance() {
-      return this.$store.state.czxpBalance;
-    },
     currentEvent() {
       return this.$store.state.lastChainEvent;
     },
-    storeCards() {
-      return this.$store.state.shop.cards;
+    displayCards() {
+      // if (this.isLoadingShopCards || !this.isShopLoadingFinished) {
+      //   return [];
+      // }
+      // const pageStart = this.isCardSorted ? this.sortedPageNext : this.pageNext;
+      // const newCards = this.$store.getters.getPaginatedShopCards(
+      //   this.pageSize,
+      //   pageStart,
+      //   this.isCardSorted
+      // );
+
+      // if (this.isCardSorted) {
+      //   this.sortedPaginatedCards = [
+      //     ...this.sortedPaginatedCards,
+      //     ...newCards.cards,
+      //   ];
+      //   this.sortedPageNext = newCards.next;
+      //   return this.sortedPaginatedCards;
+      // } else {
+      //   this.paginatedCards = [...this.paginatedCards, ...newCards.cards];
+      //   this.pageNext = newCards.next;
+      //   return this.paginatedCards;
+      // }
+      return this.isCardSorted
+        ? this.sortedPaginatedCards
+        : this.paginatedCards;
     },
+    shouldRenderLoadMore() {
+      if (this.isCardSorted) {
+        return this.sortedPageNext !== null;
+      } else {
+        return this.pageNext !== null;
+      }
+    },
+    ...mapGetters(["isLoadingShopCards", "isShopLoadingFinished"]),
   },
   watch: {
-    currentEvent(newValue,oldValue) {
-      // we only update events in the store when it concerns our wallet
-      if (newValue !== oldValue && typeof newValue !== "undefined") {
-        this.getAllTypes();
-      }
-    },
+    // currentEvent(newValue, oldValue) {
+    //   // we only update events in the store when it concerns our wallet
+    //   if (newValue !== oldValue && typeof newValue !== "undefined") {
+    //     this.$store.dispatch("fetchStoreCards");
+    //   }
+    // },
     CryptozInstance(newVal) {
       if (newVal) {
-        this.getAllTypes();
+        this.fetchStoreCards();
       }
     },
-    totalCyptozTypes(newValue, oldValue) {
-      if (newValue !== oldValue && newValue > 0) {
-        this.getAllTypes();
-      }
-    },
-    storeCards(newVal, oldVal) {
-      if (newVal !== oldVal) {
-        this.sortedCards = [...newVal]
-      }
+  },
+  mounted() {
+    if (this.isShopLoadingFinished) {
+      console.log("Shop finished after!");
     }
   },
-  data() {
-    return {
-      sortedCards: [],
-      pendingTransaction: 0,
-      transactionStatus: "Pending confirmation...",
-      showUnlimited: 1,
-      transaction_number: "",
-      typesOnChain: [],
-      buyBoostBtnOn: 0,
-      confirmBoosterBuyBtnDisabled: 0,
-      totalCreditsToBuy : 1,
-      allCards : {}, //We never mangle this,
-      buyBtnTooltipTextContent: 'Click to buy a copy of this card',
-      buyBtnBlockedTooltipTextContent:'You do not have enough BNB or CZXP tokens to purchase this card',
-      getBtnTooltipTextContent: 'Click to mint a copy of this card at no cost',
-      getBtnBlockedTooltipTextContent: 'You do not have enough CZXP tokens to unlock minting an NFT of this type',
-      getOwnedCardToolTipText: 'You can only mint 1 card of each type',
-      getSoldCardToolTipText: 'All NFTs of this type have been minted, check markets'
-    }
-  },
-  async created() {
-    this.getAllTypes = _.debounce(async function() {
-      try {
-        let showNotification = false
-        if (this.storeCards.length === 0) {
-          showPendingToast(this, 'Loading Store Cards...', {
-            autoHideDelay: 1000
-          });
-          showNotification = true
-        }
+  methods: {
+    fetchStoreCards: async function () {
+      await this.$store.dispatch("fetchStoreCards");
 
-        const typeIdsOnChain = []
+      const pageStart = this.isCardSorted ? this.sortedPageNext : this.pageNext;
+      const newCards = this.$store.getters.getPaginatedShopCards(
+        this.pageSize,
+        pageStart,
+        this.isCardSorted
+      );
 
-        //push Apr 1,2021
-        typeIdsOnChain.push(135,136,137);
-        //push March 31,2021
-        typeIdsOnChain.push(131,132,133,134);
-        //push March 27,2021
-        typeIdsOnChain.push(64,71,74,79,84,87,91,93,95,96,104);
-        //push March 20,2021
-        typeIdsOnChain.push(47,51,58,60,61,63);
-        //push March 20,2021
-        typeIdsOnChain.push(34,38,41,43);
-        //push March 19,2021
-        typeIdsOnChain.push(13,18,19,26);
-        //Dirty hack until we figure this event log shite out
-        typeIdsOnChain.push(4,5,8,22,29,31,45,56,81,101,102,103);
-
-        const results = await Promise.all(
-          typeIdsOnChain.map(async id => {
-            const cardData = await this.getCard(id);
-
-            if (!cardData) {
-              return;
-            }
-
-            return this.coinbase ? this.addIsOwnedProp(cardData) : cardData;
-          })
-        )
-        const storeCards = results.filter(result => result !== undefined);
-        this.$store.dispatch('setStoreCards', storeCards)
-
-        if (storeCards.length > 0 && showNotification) {
-          showSuccessToast(this, 'Finished Loading Shop.');
-        }
-
-      } catch (err) {
-        console.log("Error loading cards: ", err);
-        showErrorToast(this, "Failed to load shop.");
-      }
-    }, 500)
-  },
-  async mounted() {
-    if (this.web3.isConnected && this.CryptozInstance) {
-      await this.getAllTypes();
-    }
-  },
-  methods : {
-    buyCard : function(cardAttributes){
-      const cardToBuyIndex = this.sortedCards.findIndex(card => card.id === cardAttributes.id)
-      this.sortedCards[cardToBuyIndex].isOwned = true;
-      console.log("Buying card:", cardAttributes.id);
-
-      showPendingToast(this)
-
-      this.CryptozInstance.buyCard(cardAttributes.type_id, {from: this.coinbase, value:(cardAttributes.cost*1000000000000000000)})
-        .catch(err => {
-          showRejectedToast(this)
-          this.sortedCards[cardToBuyIndex].isOwned = false;
-        })
-    },
-    getCardForFree : function(type_id){
-      showPendingToast(this)
-      const cardToGet = this.sortedCards.findIndex(card => card.id === parseInt(type_id, 10))
-      this.sortedCards[cardToGet].isOwned = true;
-
-      this.CryptozInstance.getFreeCard(type_id, {from: this.coinbase})
-        .catch(err => {
-          showRejectedToast(this)
-          this.sortedCards[cardToGet].isOwned = false;
-        })
-    },
-    buyBoosters : function() {
-      this.$bvModal.hide("buy-boosters-modal");
-
-      showPendingToast(this)
-
-      var totalBoostersCost = 2000000000000000 * parseInt(this.totalCreditsToBuy);
-      this.CryptozInstance.buyBoosterCard(parseInt(this.totalCreditsToBuy), {from: this.coinbase, value:totalBoostersCost})
-        .catch(err => {
-          showRejectedToast(this)
-        })
-    },
-    addIsOwnedProp: async function (card) {
-      const isOwned = await this.CryptozInstance.cardTypesOwned(this.coinbase, card.id);
-      card.isOwned  = isOwned;
-
-      return card;
-    },
-    getCard: async function(cardId) {
-      const res = await getCardType(cardId)
-      if (!res) {
-        console.log(`Failed to fetch card ${cardId}.json`);
-        return;
-      }
-
-      let cardObj = {...res};
-
-      cardObj.id = cardId;
-
-      if (res.attributes[3].value !== "Store") {
-        return;
-      }
-
-      //format the attributes to match our JS objects
-      res.attributes.forEach(function(element) {
-        cardObj[element.trait_type] = element.value;
-      });
-
-      switch (cardObj.rarity) {
-        case "Common":
-          cardObj.rarity = "card-bg card-bg-6";
-          break;
-        case "Uncommon":
-          cardObj.rarity = "card-bg card-bg-5";
-          break;
-        case "Rare":
-          cardObj.rarity = "card-bg card-bg-4";
-          break;
-        case "Epic":
-          cardObj.rarity = "card-bg card-bg-3";
-          break;
-        case "Diamond":
-          cardObj.rarity = "card-bg card-bg-2";
-          break;
-        case "Platinum":
-          cardObj.rarity = "card-bg card-bg-1";
-          break;
-      }
-
-      //Get NFTs minted already to inject in our edition totals
-      this.CryptozInstance.cardTypeToEdition(cardObj.id)
-        .then((result) => {
-          cardObj.edition_current = parseInt(result)
-
-          //Edition bug hack
-          if(cardObj.id == 102){ //dragon edition limit bug ?
-            cardObj.edition_total = 5;
-          }
-          if(cardObj.id == 103){ //bleeding fury edition limit bug ?
-            cardObj.edition_total = 1;
-          }
-          if(cardObj.id == 5){ //stu bug ?
-            cardObj.edition_total = 110;
-          }
-          if(cardObj.id == 22){ //thrny bug ?
-            cardObj.edition_total = 179;
-          }
-          if(cardObj.id == 56){ //shroom ?
-            cardObj.edition_total = 112;
-          }
-          if(cardObj.id == 19){ //guts r us
-            cardObj.edition_total = 80;
-          }
-          if(cardObj.id == 43){ //medula
-            cardObj.edition_total = 215;
-          }
-          if(cardObj.id == 26){ //zombie egg
-            cardObj.edition_total = 288;
-          }
-          if(cardObj.id == 104){ //grumps
-            cardObj.edition_total = 7;
-          }
-          if(cardObj.id == 60){ //wraith
-            cardObj.edition_total = 384;
-          }
-          if(cardObj.id == 93){ //elephant
-            cardObj.edition_total = 49;
-          }
-          if(cardObj.id == 74){ //dust bunny
-            cardObj.edition_total = 189;
-          }
-          if(cardObj.id == 96){ //lemur
-            cardObj.edition_total = 109;
-          }
-          if(cardObj.id == 133){ //blue brain coral
-            cardObj.edition_total = 309;
-          }
-
-
-          // Set soldOut flag first
-          if(cardObj.edition_current == cardObj.edition_total) {
-            cardObj.soldOut = 1;
-          }
-        })
-        .catch(err => {
-          console.error('Error getting NFTs minted:', err);
-        })
-
-      this.allCards[cardObj.type_id] = cardObj;
-      return cardObj;
-    },
-    buyBtnTooltipText(cost, unlock_czxp) {
-      if (this.balance <= cost || this.czxpBalance < parseInt(unlock_czxp)) {
-        return this.buyBtnBlockedTooltipTextContent
+      if (this.isCardSorted) {
+        this.sortedPaginatedCards = [
+          ...this.sortedPaginatedCards,
+          ...newCards.cards,
+        ];
+        this.sortedPageNext = newCards.next;
       } else {
-        return this.buyBtnTooltipTextContent
+        this.paginatedCards = [...this.paginatedCards, ...newCards.cards];
+        this.pageNext = newCards.next;
+      }
+    },
+    loadMoreCards: function () {
+      if (this.isCardSorted) {
+        const newCards = this.$store.getters.getPaginatedShopCards(
+          this.pageSize,
+          this.sortedPageNext,
+          this.isCardSorted
+        );
+
+        this.sortedPaginatedCards = [
+          ...this.sortedPaginatedCards,
+          ...newCards.cards,
+        ];
+        this.sortedPageNext = newCards.next;
+      } else {
+        const newCards = this.$store.getters.getPaginatedShopCards(
+          this.pageSize,
+          this.pageNext,
+          this.isCardSorted
+        );
+
+        this.paginatedCards = [...this.paginatedCards, ...newCards.cards];
+        this.pageNext = newCards.next;
       }
     },
     getBtnTooltipText(unlock_czxp) {
       if (this.czxpBalance < parseInt(unlock_czxp)) {
-        return this.getBtnBlockedTooltipTextContent
+        return this.getBtnBlockedTooltipTextContent;
       } else {
-        return this.getBtnTooltipTextContent
+        return this.getBtnTooltipTextContent;
       }
     },
-    sortByAttr: function(param, isDescending) {
-      switch(param) {
-        case "edition_number":
-          this.sortedCards.sort(dynamicSort('edition_current', isDescending, false));
-          break
-        case "rarity":
-          this.sortedCards.sort(dynamicSort(param, isDescending, true, getRarity))
-          break
-        default:
-          this.sortedCards.sort(dynamicSort(param, isDescending))
-          break
+    getCardForFree: async function (type_id) {
+      try {
+        showPendingToast(this);
+        this.$store.dispatch("setCardAsBought", {
+          cardId: type_id,
+          isSorted: this.isCardSorted,
+        });
+
+        const result = await this.CryptozInstance.getFreeCard(type_id, {
+          from: this.coinbase,
+        });
+
+        if (result) {
+          showSuccessToast(this, `Got Card: ${type_id}`);
+          this.$store.dispatch("setCurrentEdition", {
+            cardId: type_id,
+            isSorted: this.isCardSorted,
+          });
+        }
+      } catch (err) {
+        console.error(err);
+        this.$store.dispatch("setCardAsNotBought", {
+          cardId: type_id,
+          isSorted: this.isCardSorted,
+        });
+        showRejectedToast(this);
       }
-    }
-  }
-}
+    },
+    buyCard: async function (cardAttributes) {
+      try {
+        console.log("Buying card:", cardAttributes.id);
+        showPendingToast(this);
+        this.$store.dispatch("setCardAsBought", {
+          cardId: cardAttributes.id,
+          isSorted: this.isCardSorted,
+        });
+        const result = await this.CryptozInstance.buyCard(
+          cardAttributes.type_id,
+          {
+            from: this.coinbase,
+            value: cardAttributes.cost * 1000000000000000000,
+          }
+        );
+        if (result) {
+          showSuccessToast(this, `Bought card: ${cardAttributes.id}!`);
+          this.$store.dispatch("setCurrentEdition", {
+            cardId: cardAttributes.id,
+            isSorted: this.isCardSorted,
+          });
+        }
+      } catch (err) {
+        console.error("Failed to buy cards. ", err);
+        showRejectedToast(this);
+        this.$store.dispatch("setCardAsNotBought", {
+          cardId: cardAttributes.id,
+          isSorted: this.isCardSorted,
+        });
+      }
+    },
+    buyBtnTooltipText(cost, unlock_czxp) {
+      if (this.balance <= cost || this.czxpBalance < parseInt(unlock_czxp)) {
+        return this.buyBtnBlockedTooltipTextContent;
+      } else {
+        return this.buyBtnTooltipTextContent;
+      }
+    },
+    buyBoosters: async function () {
+      try {
+        this.$bvModal.hide("buy-boosters-modal");
+        showPendingToast(this);
+        this.isBuyingBooster = true;
+        const totalBoostersCost =
+          2000000000000000 * parseInt(this.totalCreditsToBuy);
+
+        const result = await this.CryptozInstance.buyBoosterCard(
+          parseInt(this.totalCreditsToBuy),
+          { from: this.coinbase, value: totalBoostersCost }
+        );
+
+        if (result) {
+          showSuccessToast(this, "Successfully Bought Booster!");
+        }
+      } catch (err) {
+        console.error("Failed to buy booster: ", err);
+        showRejectedToast(this);
+      } finally {
+        this.isBuyingBooster = false;
+      }
+    },
+    sortByAttr: async function (param, isDescending) {
+      if (!param) {
+        // We cleared sort.
+        // Clear all data so we start with a new page of sort
+        this.isCardSorted = false;
+        this.sortedPaginatedCards = [];
+        this.sortedPageNext = 0;
+        return;
+      }
+
+      this.sortedPaginatedCards = [];
+      this.sortedPageNext = 0;
+      this.isCardSorted = true;
+      await this.$store.dispatch("sortCards", {
+        param,
+        isDescending,
+      });
+
+      const newCards = this.$store.getters.getPaginatedShopCards(
+        this.pageSize,
+        this.sortedPageNext,
+        this.isCardSorted
+      );
+
+      this.sortedPaginatedCards = [...newCards.cards];
+      this.sortedPageNext = newCards.next;
+    },
+  },
+};
 </script>
 
-<!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
-  .jumbotron {
-    margin: auto;
-    width: 95%;
-  }
-  .spinner {
-    width: 2em;
-  }
-  .fade-enter-active,
-  .fade-leave-active {
-    transition: opacity .10s;
-  }
-  .fade-enter,
-  .fade-leave-to /* .fade-leave-active below version 2.1.8 */ {
-    opacity: 0;
-  }
-  #buy-get-button-wrapper,
-  #owned-button-wrapper,
-  #sold-button-wrapper {
-    position: relative;
-    text-align: center;
-  }
-  /* add a little arrow for users to be sure which they're purchasing */
-  #buy-get-button-wrapper::before,
-  #owned-button-wrapper::before {
-    content: '';
-    position: absolute;
-    top:-10px;
-    left: 50%;
-    transform: translateX(-50%);
-    border-left: 10px solid transparent;
-    border-right: 10px solid transparent;
-    border-bottom: 10px solid #007bff;
-  }
+#buy-get-button-wrapper,
+#owned-button-wrapper,
+#sold-button-wrapper {
+  position: relative;
+  text-align: center;
+}
 
-  #owned-button-wrapper::before {
-    border-bottom: 10px solid #17a2b8;
-  }
+#sold-button-wrapper::before {
+  content: "";
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-bottom: 10px solid #dc3545;
+}
 
-  #sold-button-wrapper::before {
-    content: '';
-    position: absolute;
-    top:-10px;
-    left: 50%;
-    transform: translateX(-50%);
-    border-left: 10px solid transparent;
-    border-right: 10px solid transparent;
-    border-bottom: 10px solid #dc3545;
-  }
+.disabled-btn::before {
+  opacity: 0.65;
+}
 
-  .disabled-btn::before {
-    opacity: .65;
-  }
+.owner-balances {
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
 
-  .flex-row {
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: space-around;
-  }
+.loading {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  margin-top: 36px;
+}
 
+.sort-wrapper {
+  margin-bottom: 36px;
+}
+
+.shop-card-item {
+  display: flex;
+  flex-direction: column;
+  width: 260px;
+}
+
+.flex-row {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-around;
+}
+
+.card-button-container {
+  display: flex;
+  justify-content: center;
+}
+
+.card-button-container button {
+  font-size: 16px;
+}
+
+.load-more {
+  width: 100%;
+  margin-top: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media screen and (max-width: 800px) {
   .shop-card-item {
-    display: flex;
-    flex-direction: column;
-    width: 260px;
+    width: calc(0.55 * 260px);
   }
 
   .card-button-container {
-    display: flex;
-    justify-content: center;
+    margin-top: 5px;
   }
 
   .card-button-container button {
-    font-size: 16px;
+    padding: 3%;
+    font-size: 12px;
+    width: 80%;
   }
 
-  @media screen and (max-width: 800px) {
-    .shop-card-item {
-      width: calc(0.55 * 260px);
-    }
-
-    .card-button-container {
-      margin-top: 5px;
-    }
-
-    .card-button-container button {
-      padding: 3%;
-      font-size: 12px;
-      width: 80%;
-    }
+  .card-button-container {
+    margin-top: 5px;
   }
+
+  .card-button-container button {
+    padding: 3%;
+    font-size: 12px;
+    width: 80%;
+  }
+}
 </style>

--- a/src/components/ShopContent.vue
+++ b/src/components/ShopContent.vue
@@ -305,8 +305,8 @@ export default {
     },
   },
   mounted() {
-    if (this.isShopLoadingFinished) {
-      console.log("Shop finished after!");
+    if (this.CryptozInstance) {
+      this.fetchStoreCards();
     }
   },
   methods: {

--- a/src/components/SortDropdown.vue
+++ b/src/components/SortDropdown.vue
@@ -1,27 +1,36 @@
 <template>
-  <div>
-    <b-dropdown
-      :disabled="disabled"
-      id="dropdown"
-      :text="'Sort by ' + (sortType ? types[sortType] : '')"
-    >
-      <b-dropdown-item
-        v-for="(name, type) in types"
-        :key="type"
-        @click="callSort(type)"
+  <div class="dropdown-wrapper">
+    <div>
+      <b-dropdown
+        :disabled="disabled"
+        id="dropdown"
+        :text="'Sort by ' + (sortType ? types[sortType] : '')"
       >
-        {{ name }}
-      </b-dropdown-item>
-    </b-dropdown>
+        <b-dropdown-item
+          v-for="(name, type) in types"
+          :key="type"
+          @click="callSort(type)"
+        >
+          {{ name }}
+        </b-dropdown-item>
+      </b-dropdown>
 
+      <b-button
+        v-if="sortType"
+        id="toggle-order-button"
+        @click="toggleOrder"
+        v-b-tooltip.hover="'Toggle sort order'"
+      >
+        {{ isDescending ? "🡦" : "🡥" }}
+      </b-button>
+    </div>
     <b-button
-      v-if="sortType"
-      id="toggle-order-button"
-      @click="toggleOrder"
-      v-b-tooltip.hover="'Toggle sort order'"
+      class="clear-sorting"
+      variant="outline-warning"
+      @click="clearSortFilter"
+      v-if="isSorting"
+      >Clear Sort Filter</b-button
     >
-      {{ isDescending ? "🡦" : "🡥" }}
-    </b-button>
   </div>
 </template>
 
@@ -44,6 +53,7 @@ export default {
     return {
       isDescending: false,
       sortType: null,
+      isSorting: false,
       types: {
         name: "Name",
         rarity: "Rarity",
@@ -61,11 +71,17 @@ export default {
   methods: {
     callSort(param) {
       this.sortType = param;
+      this.isSorting = true;
       this.$emit("sort-by-attr", param, this.isDescending);
     },
     toggleOrder() {
       this.isDescending = !this.isDescending;
       this.callSort(this.sortType);
+    },
+    clearSortFilter() {
+      this.isSorting = false;
+      this.sortType = null;
+      this.$emit("sort-by-attr", null, this.isDescending);
     },
   },
 };
@@ -75,5 +91,27 @@ export default {
 <style scoped>
 #toggle-order-button {
   margin-left: 0.5rem;
+}
+
+.clear-sorting {
+  margin-top: 10px;
+}
+
+.dropdown-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Desktop CSS */
+@media only screen and (min-width: 500px) {
+  .clear-sorting {
+    margin-top: 0px;
+    margin-left: 16px;
+    max-width: 250px;
+  }
+
+  .dropdown-wrapper {
+    flex-direction: row;
+  }
 }
 </style>

--- a/src/store/cardStore.js
+++ b/src/store/cardStore.js
@@ -177,7 +177,7 @@ const cardStore = {
      *
      */
     [CARD_MUTATIONS.SET_SHOP_CARDS](state, payload) {
-      state.allShopCards = [...state.allShopCards, ...payload];
+      state.allShopCards = [...payload];
       state.shopLoaded = true;
       state.isLoadingShop = false;
       state.failedToLoadShop = false;

--- a/src/store/cardStore.js
+++ b/src/store/cardStore.js
@@ -1,0 +1,334 @@
+import Vue from "vue";
+import Vuex from "vuex";
+import getCardType from "../util/getCardType";
+import state from "./state";
+import { dynamicSort, getRarity } from "../helpers";
+
+const typeIdsOnChain = [];
+
+//push Apr 1,2021
+typeIdsOnChain.push(135, 136, 137);
+//push March 31,2021
+typeIdsOnChain.push(131, 132, 133, 134);
+//push March 27,2021
+typeIdsOnChain.push(64, 71, 74, 79, 84, 87, 91, 93, 95, 96, 104);
+//push March 20,2021
+typeIdsOnChain.push(47, 51, 58, 60, 61, 63);
+//push March 20,2021
+typeIdsOnChain.push(34, 38, 41, 43);
+//push March 19,2021
+typeIdsOnChain.push(13, 18, 19, 26);
+//Dirty hack until we figure this event log shite out
+typeIdsOnChain.push(4, 5, 8, 22, 29, 31, 45, 56, 81, 101, 102, 103);
+
+const DEFAULT_CARD_STATE = {
+  allShopCards: [],
+  sortedCards: [],
+  isLoadingShop: false,
+  failedToLoadShop: false,
+  shopLoaded: false,
+  ownedCards: {},
+  isLoadingOwnedCards: false,
+  failedToLoadOwnedCards: false,
+  othersCards: {},
+  isLoadingOthersCards: false,
+  failedToLoadOthersCards: false,
+};
+
+export const CARD_MUTATIONS = {
+  SET_SHOP_CARDS: "SET_SHOP_CARDS",
+  LOADING_SHOP_CARDS: "LOADING_SHOP_CARDS",
+  LOADING_SHOP_CARDS_FAILED: "LOADING_SHOP_CARDS_FAILED",
+  SET_SORTED_CARDS: "SET_SORTED_CARDS",
+  SET_CARD_BOUGHT: "SET_CARD_BOUGHT",
+  SET_CARD_NOT_BOUGHT: "SET_CARD_NOT_BOUGHT",
+  SET_CARD_EDITION: "SET_CARD_EDITION"
+};
+
+const RARITY = {
+  Common: "card-bg card-bg-6",
+  Uncommon: "card-bg card-bg-5",
+  Rare: "card-bg card-bg-4",
+  Epic: "card-bg card-bg-3",
+  Diamond: "card-bg card-bg-2",
+  Platinum: "card-bg card-bg-1",
+};
+
+/**
+ * Hack for our edition bug
+ * Key: card ID
+ * Value: hard coded edition total
+ *
+ * If we need to add further hacks, just append an entry to this object
+ */
+const EDITION_HACK = {
+  102: 5,
+  103: 1,
+  5: 110,
+  22: 179,
+  56: 122,
+  19: 80,
+  43: 215,
+  26: 288,
+  104: 7,
+  93: 49,
+  74: 189,
+  96: 109,
+  60: 384,
+  133: 309,
+};
+
+const getCard = async (cardId, CryptozInstance) => {
+  const res = await getCardType(cardId);
+  if (!res) {
+    console.log(`Failed to fetch card ${cardId}.json`);
+    return;
+  }
+
+  let cardObj = { ...res };
+
+  cardObj.id = cardId;
+
+  if (res.attributes[3].value !== "Store") {
+    return;
+  }
+
+  // using for..of here so I can use continue
+  for (const attribute of res.attributes) {
+    if (attribute.trait_type === "rarity") {
+      cardObj["rarity"] = RARITY[attribute.value];
+      continue;
+    }
+    cardObj[attribute.trait_type] = attribute.value;
+  }
+
+  const edition = await CryptozInstance.cardTypeToEdition(cardObj.id);
+
+  cardObj.edition_current = parseInt(edition);
+
+  if (EDITION_HACK[cardObj.id]) {
+    cardObj.edition_total = EDITION_HACK[cardObj.id];
+  }
+
+  // Set soldOut flag first
+  if (cardObj.edition_current == cardObj.edition_total) {
+    cardObj.soldOut = 1;
+  }
+
+  return cardObj;
+};
+
+const addIsOwnedProp = async (card, CryptozInstance, coinbase) => {
+  const isOwned = await CryptozInstance.cardTypesOwned(coinbase, card.id);
+  card.isOwned = isOwned;
+
+  return card;
+};
+
+const cardStore = {
+  state: DEFAULT_CARD_STATE,
+  mutations: {
+    [CARD_MUTATIONS.SET_CARD_EDITION](state, payload) {
+      const {cardId, edition, isSorted} = payload;
+
+      if (isSorted) {
+        const sortedIndex = state.sortedCards.findIndex(card => card.id === cardId);
+        state.sortedCards[sortedIndex].edition_current = edition;
+      }
+
+      const index = state.allShopCards.findIndex(card => card.id === cardId);
+      state.allShopCards[index].edition_current = edition;
+    },
+    [CARD_MUTATIONS.SET_CARD_BOUGHT](state, payload) {
+      const { cardId, isSorted } = payload;
+      const parsedCardId = parseInt(cardId)
+
+      if (isSorted) {
+        const cardSortedIndex = state.sortedCards.findIndex(
+          (card) => card.id === parsedCardId
+        )
+        state.sortedCards[cardSortedIndex].isOwned = true;
+      } else {
+        const cardBoughtIndex = state.allShopCards.findIndex(
+          (card) => card.id === parsedCardId
+        );
+        state.allShopCards[cardBoughtIndex].isOwned = true;
+      }
+    },
+    [CARD_MUTATIONS.SET_CARD_NOT_BOUGHT](state, payload) {
+      const { cardId, isSorted } = payload;
+      const parsedCardId = parseInt(cardId)
+
+      if (isSorted) {
+        const cardSortedIndex = state.sortedCards.findIndex(
+          (card) => card.id === parsedCardId
+        )
+        state.sortedCards[cardSortedIndex].isOwned = false;
+      } else {
+        const cardBoughtIndex = state.allShopCards.findIndex(
+          (card) => card.id === parsedCardId
+        );
+        state.allShopCards[cardBoughtIndex].isOwned = false;
+      }
+    },
+    /**
+     * @param {DEFAULT_CARD_STATE} state
+     * @param {Array<card>} payload
+     *
+     */
+    [CARD_MUTATIONS.SET_SHOP_CARDS](state, payload) {
+      state.allShopCards = [...state.allShopCards, ...payload];
+      state.shopLoaded = true;
+      state.isLoadingShop = false;
+      state.failedToLoadShop = false;
+    },
+    [CARD_MUTATIONS.LOADING_SHOP_CARDS](state) {
+      state.isLoadingShop = true;
+      state.shopLoaded = false;
+    },
+    [CARD_MUTATIONS.LOADING_SHOP_CARDS_FAILED](state) {
+      state.failedToLoadShop = true;
+      state.shopLoaded = false;
+    },
+    [CARD_MUTATIONS.SET_SORTED_CARDS](state, payload) {
+      const { allShopCards, sortParam } = payload;
+      const shopCards = [...allShopCards];
+
+      switch (sortParam.param) {
+        case "edition_number":
+          shopCards.sort(
+            dynamicSort("edition_current", sortParam.isDescending, false)
+          );
+          break;
+        case "rarity":
+          shopCards.sort(
+            dynamicSort(
+              sortParam.param,
+              sortParam.isDescending,
+              true,
+              getRarity
+            )
+          );
+          break;
+        default:
+          shopCards.sort(dynamicSort(sortParam.param, sortParam.isDescending));
+          break;
+      }
+
+      state.sortedCards = shopCards;
+    },
+  },
+  actions: {
+    async setCurrentEdition({commit, rootState}, payload) {
+      try {
+        const CryptozInstance = rootState.contractInstance.cryptoz;
+
+        const {cardId, isSorted} = payload;
+        const parsedId = parseInt(cardId);
+  
+        const edition = await CryptozInstance.cardTypeToEdition(parsedId);
+
+        commit(CARD_MUTATIONS.SET_CARD_EDITION, {
+          cardId: parsedId,
+          edition,
+          isSorted
+        })
+      } catch (err) {
+        console.error(err);
+      }
+
+    },
+    async fetchStoreCards({ commit, rootState }) {
+      try {
+        const CryptozInstance = rootState.contractInstance.cryptoz;
+        commit(CARD_MUTATIONS.LOADING_SHOP_CARDS);
+
+        const results = await Promise.all(
+          typeIdsOnChain.map(async (id) => {
+            const cardData = await getCard(id, CryptozInstance);
+
+            if (!cardData) {
+              return;
+            }
+
+            return rootState.web3.coinbase
+              ? await addIsOwnedProp(
+                  cardData,
+                  CryptozInstance,
+                  rootState.web3.coinbase
+                )
+              : cardData;
+          })
+        );
+        const storeCards = results.filter((result) => result !== undefined);
+        commit(CARD_MUTATIONS.SET_SHOP_CARDS, storeCards);
+      } catch (err) {
+        console.error("Failed to load shop cards", { err });
+        commit(CARD_MUTATIONS.LOADING_SHOP_CARDS_FAILED);
+      }
+    },
+    sortCards({ commit, state }, payload) {
+      commit(CARD_MUTATIONS.SET_SORTED_CARDS, {
+        allShopCards: state.allShopCards,
+        sortParam: payload,
+      });
+    },
+    setCardAsBought({ commit }, payload) {
+      commit(CARD_MUTATIONS.SET_CARD_BOUGHT, payload);
+    },
+    setCardAsNotBought({ commit }, payload) {
+      commit(CARD_MUTATIONS.SET_CARD_NOT_BOUGHT, payload);
+    },
+  },
+  getters: {
+    getPaginatedShopCards: (state) => (pageSize, start, isSorted) => {
+      const cardsToReturn = isSorted ? state.sortedCards : state.allShopCards;
+      if (cardsToReturn.length === 0) {
+        return [];
+      }
+
+      let pageNext, endIndex;
+      if (!!start) {
+        if (start + pageSize > cardsToReturn.length) {
+          pageNext = null;
+          endIndex = cardsToReturn.length;
+        } else {
+          pageNext = start + pageSize;
+          endIndex = start + pageSize;
+        }
+      } else {
+        if (pageSize > cardsToReturn.length) {
+          pageNext = null;
+          endIndex = cardsToReturn.length;
+        } else {
+          pageNext = pageSize;
+          endIndex = pageSize;
+        }
+      }
+
+      if (!!start) {
+        // Return pagesize from this start
+        return {
+          cards: cardsToReturn.slice(start, endIndex),
+          next: pageNext,
+        };
+      } else {
+        return {
+          cards: cardsToReturn.slice(0, endIndex),
+          next: pageNext,
+        };
+      }
+    },
+    isLoadingShopCards: (state) => {
+      return state.isLoadingShop;
+    },
+    isLoadingShopFailed: (state) => {
+      return state.failedToLoadShop;
+    },
+    isShopLoadingFinished: (state) => {
+      return state.shopLoaded;
+    },
+  },
+};
+
+export default cardStore;

--- a/src/store/cardStore.js
+++ b/src/store/cardStore.js
@@ -76,6 +76,7 @@ const EDITION_HACK = {
   96: 109,
   60: 384,
   133: 309,
+  137: 3,
 };
 
 const getCard = async (cardId, CryptozInstance) => {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import Vuex from 'vuex'
 import state from './state'
 import { showSuccessToast } from "../util/showToast";
+import cardStore from './cardStore';
 
 Vue.use(Vuex)
 
@@ -139,5 +140,8 @@ export const store = new Vuex.Store({
     setLastEvent ({commit}, payload) {
       commit('setLastEvent', payload)
     },
+  },
+  modules: {
+    cards: cardStore
   }
 })

--- a/src/util/getCardType.js
+++ b/src/util/getCardType.js
@@ -1,11 +1,12 @@
-import axios from 'axios';
-
-const cardTypeBaseUrl = `https://cryptoz.cards/services/card_types`
-
 const getCardType = async (cardId) => {
-    const result = await axios.get(`${cardTypeBaseUrl}/${cardId}.json`);
-    
-    return result.data
+    try {
+        const cardType = await import("../card_types/" + cardId + ".json")
+        return {
+            ...cardType.default
+        }
+    } catch (err) {
+        console.error(err);
+    }
 }
 
 export default getCardType


### PR DESCRIPTION
Work done:
- Added a clear filter for sorting dropdown. Currently, this clear filter only works for the shop because we have states set up. We can add this to crypt when working on infinite scroll for that component
- Refactored everything shop card related into `cardStore.js`. This should be a single source of truth on store cards (in the future all kind of cards) going forward
- Added infinite scroll for shop component with a load more button. In the future, if this feature is tested and stabilized we can easily switch to trigger on scroll. 
- Separated the states for sorted and unsorted shop cards. For example, if a user loaded 50 cards through infinite scrolling unsorted when we sort we will still display 10 cards. This is because sorted cards and unsorted are separate states. If the user clears the sort, we will display all 50 loaded unsorted cards. 

I don't suggest looking at the changes made to `ShopContent.vue`. If you really wanna take a look at the code, you should pull down the branch and look at `ShopContent.vue` and `cardStore.js`, which hold the majority of the changes. 

Lastly, **probably need a loooooot of testing.** try to break this if you can