### PR TITLE
use detectEthereumProvider instead of manually checking

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -54,7 +54,9 @@ import "./main.css";
 import zoombiesContractJSON from "./contracts/Zoombies.json";
 import zoomTokenContractJSON from "./contracts/ZoomToken.json";
 
-const isLocal = (process.env.NODE_ENV === "development" || window.location.host !== 'movr.zoombies.world');
+const isLocal =
+  process.env.NODE_ENV === "development" ||
+  window.location.host !== "movr.zoombies.world";
 
 const ethChainParam = isLocal
   ? {
@@ -178,7 +180,7 @@ export default {
       this.handleConnect();
     });
   },
-  mounted() {
+  async mounted() {
     // Twitter library - footer follow button uses it
     window.twttr = (function (d, s, id) {
       var js,
@@ -198,7 +200,11 @@ export default {
       return t;
     })(document, "script", "twitter-wjs");
 
-    if (window.web3 === undefined || window.ethereum === undefined) {
+    const provider = await detectEthereumProvider({
+      mustBeMetaMask: true,
+    });
+
+    if (!provider) {
       this.$bvModal.show("no-web3-modal");
     }
   },


### PR DESCRIPTION
`@metamask/detect-provider` can be used to detect metamask on mobile devices too. We weren't using it before and therefore couldn't detect mobile metamask.

I think I can only test this on mobile once it's deployed to moonbase. But I tested with safari and chrome incognito and it still works. But it seems like `detect-provider` has a delay when detecting