### PR TITLE
rpc endpoint for moonbase updated

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -148,7 +148,7 @@ const ethChainParam = isLocal
         symbol: "DEV",
         decimals: 18,
       },
-      rpcUrls: ["https://rpc.testnet.moonbeam.network"],
+      rpcUrls: ["https://moonbeam-alpha.api.onfinality.io/public"],
       blockExplorerUrls: [
         "https://moonbase-blockscout.testnet.moonbeam.network/",
       ],


### PR DESCRIPTION
To test.
Remove Moonbase Alpha from Networks. 
load the dapp. when prompted, add the moonbase alpha network. Click Connect
view Crypt